### PR TITLE
Integra migrations, models e controllers gerados via scaffold na branch develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Auto-correct Ruby code with RuboCop
+        run: bin/rubocop -A
+
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,9 @@ jobs:
             sleep 1
           done
           
-      - name: Setup test database
+      - name: Reset and setup test database
         run: |
-          bin/rails db:create
-          bin/rails db:migrate
+          bin/rails db:drop db:create db:migrate RAILS_ENV=test
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
@@ -88,4 +87,4 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test
+        run: bin/rails test

--- a/app/controllers/artigos_controller.rb
+++ b/app/controllers/artigos_controller.rb
@@ -1,0 +1,51 @@
+class ArtigosController < ApplicationController
+  before_action :set_artigo, only: %i[ show update destroy ]
+
+  # GET /artigos
+  def index
+    @artigos = Artigo.all
+
+    render json: @artigos
+  end
+
+  # GET /artigos/1
+  def show
+    render json: @artigo
+  end
+
+  # POST /artigos
+  def create
+    @artigo = Artigo.new(artigo_params)
+
+    if @artigo.save
+      render json: @artigo, status: :created, location: @artigo
+    else
+      render json: @artigo.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /artigos/1
+  def update
+    if @artigo.update(artigo_params)
+      render json: @artigo
+    else
+      render json: @artigo.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /artigos/1
+  def destroy
+    @artigo.destroy!
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_artigo
+      @artigo = Artigo.find(params.expect(:id))
+    end
+
+    # Only allow a list of trusted parameters through.
+    def artigo_params
+      params.expect(artigo: [ :titulo, :conteudo, :tags, :url_imagem, :local, :data, :autor_id ])
+    end
+end

--- a/app/controllers/autors_controller.rb
+++ b/app/controllers/autors_controller.rb
@@ -1,0 +1,51 @@
+class AutorsController < ApplicationController
+  before_action :set_autor, only: %i[ show update destroy ]
+
+  # GET /autors
+  def index
+    @autors = Autor.all
+
+    render json: @autors
+  end
+
+  # GET /autors/1
+  def show
+    render json: @autor
+  end
+
+  # POST /autors
+  def create
+    @autor = Autor.new(autor_params)
+
+    if @autor.save
+      render json: @autor, status: :created, location: @autor
+    else
+      render json: @autor.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /autors/1
+  def update
+    if @autor.update(autor_params)
+      render json: @autor
+    else
+      render json: @autor.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /autors/1
+  def destroy
+    @autor.destroy!
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_autor
+      @autor = Autor.find(params.expect(:id))
+    end
+
+    # Only allow a list of trusted parameters through.
+    def autor_params
+      params.expect(autor: [ :nome, :foto, :email, :senha ])
+    end
+end

--- a/app/controllers/eventos_controller.rb
+++ b/app/controllers/eventos_controller.rb
@@ -1,0 +1,51 @@
+class EventosController < ApplicationController
+  before_action :set_evento, only: %i[ show update destroy ]
+
+  # GET /eventos
+  def index
+    @eventos = Evento.all
+
+    render json: @eventos
+  end
+
+  # GET /eventos/1
+  def show
+    render json: @evento
+  end
+
+  # POST /eventos
+  def create
+    @evento = Evento.new(evento_params)
+
+    if @evento.save
+      render json: @evento, status: :created, location: @evento
+    else
+      render json: @evento.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /eventos/1
+  def update
+    if @evento.update(evento_params)
+      render json: @evento
+    else
+      render json: @evento.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /eventos/1
+  def destroy
+    @evento.destroy!
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_evento
+      @evento = Evento.find(params.expect(:id))
+    end
+
+    # Only allow a list of trusted parameters through.
+    def evento_params
+      params.expect(evento: [ :titulo, :conteudo, :tags, :url_imagem, :local, :data, :autor_id ])
+    end
+end

--- a/app/models/artigo.rb
+++ b/app/models/artigo.rb
@@ -1,0 +1,6 @@
+#belongs_to = pertence_a
+#optional: true permite que isso seja falso
+
+class Artigo < ApplicationRecord
+  belongs_to :autor, optional:true
+end

--- a/app/models/artigo.rb
+++ b/app/models/artigo.rb
@@ -1,6 +1,6 @@
-#belongs_to = pertence_a
-#optional: true permite que isso seja falso
+# belongs_to = pertence_a
+# optional: true permite que isso seja falso
 
 class Artigo < ApplicationRecord
-  belongs_to :autor, optional:true
+  belongs_to :autor, optional: true
 end

--- a/app/models/autor.rb
+++ b/app/models/autor.rb
@@ -1,0 +1,6 @@
+#Definindo as cardinalidades/relacionamentos entre tabelas
+#dependent: :nullify se o autor for deletado, artigos ficam com autor_id = NULL
+class Autor < ApplicationRecord
+  has_many :artigos, dependent: :nullify
+  has_many :eventos, dependent: :nullify
+end

--- a/app/models/autor.rb
+++ b/app/models/autor.rb
@@ -1,5 +1,5 @@
-#Definindo as cardinalidades/relacionamentos entre tabelas
-#dependent: :nullify se o autor for deletado, artigos ficam com autor_id = NULL
+# Definindo as cardinalidades/relacionamentos entre tabelas
+# dependent: :nullify se o autor for deletado, artigos ficam com autor_id = NULL
 class Autor < ApplicationRecord
   has_many :artigos, dependent: :nullify
   has_many :eventos, dependent: :nullify

--- a/app/models/evento.rb
+++ b/app/models/evento.rb
@@ -1,6 +1,6 @@
-#belongs_to = pertence_a
-#optional: true permite que isso seja falso
+# belongs_to = pertence_a
+# optional: true permite que isso seja falso
 
 class Evento < ApplicationRecord
-  belongs_to :autor, optional:true
+  belongs_to :autor, optional: true
 end

--- a/app/models/evento.rb
+++ b/app/models/evento.rb
@@ -1,0 +1,6 @@
+#belongs_to = pertence_a
+#optional: true permite que isso seja falso
+
+class Evento < ApplicationRecord
+  belongs_to :autor, optional:true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  resources :eventos
+  resources :artigos
+  resources :autors
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250920001750_create_autors.rb
+++ b/db/migrate/20250920001750_create_autors.rb
@@ -1,10 +1,10 @@
 class CreateAutors < ActiveRecord::Migration[8.0]
   def change
     create_table :autors do |t|
-      t.string :nome, null:false
+      t.string :nome, null: false
       t.string :foto
-      t.string :email, null:false
-      t.string :senha, null:false
+      t.string :email, null: false
+      t.string :senha, null: false
     end
     add_index :autors, :email, unique: true
   end

--- a/db/migrate/20250920001750_create_autors.rb
+++ b/db/migrate/20250920001750_create_autors.rb
@@ -1,0 +1,11 @@
+class CreateAutors < ActiveRecord::Migration[8.0]
+  def change
+    create_table :autors do |t|
+      t.string :nome, null:false
+      t.string :foto
+      t.string :email, null:false
+      t.string :senha, null:false
+    end
+    add_index :autors, :email, unique: true
+  end
+end

--- a/db/migrate/20250920001855_create_artigos.rb
+++ b/db/migrate/20250920001855_create_artigos.rb
@@ -1,14 +1,14 @@
 class CreateArtigos < ActiveRecord::Migration[8.0]
   def change
     create_table :artigos do |t|
-      t.string :titulo, null:false
-      t.text :conteudo, null:false
-      t.text :tags, array:true, default:[]
+      t.string :titulo, null: false
+      t.text :conteudo, null: false
+      t.text :tags, array: true, default: []
       t.string :url_imagem
-      t.string :local, null:false
+      t.string :local, null: false
       t.column :data, :timestamptz, default: -> { "TIMEZONE('America/Sao_Paulo', NOW())" }
 
-      t.references :autor, null: true, foreign_key: {on_delete: :nullify}
+      t.references :autor, null: true, foreign_key: { on_delete: :nullify }
     end
   end
 end

--- a/db/migrate/20250920001855_create_artigos.rb
+++ b/db/migrate/20250920001855_create_artigos.rb
@@ -1,0 +1,14 @@
+class CreateArtigos < ActiveRecord::Migration[8.0]
+  def change
+    create_table :artigos do |t|
+      t.string :titulo, null:false
+      t.text :conteudo, null:false
+      t.text :tags, array:true, default:[]
+      t.string :url_imagem
+      t.string :local, null:false
+      t.column :data, :timestamptz, default: -> { "TIMEZONE('America/Sao_Paulo', NOW())" }
+
+      t.references :autor, null: true, foreign_key: {on_delete: :nullify}
+    end
+  end
+end

--- a/db/migrate/20250920002438_create_eventos.rb
+++ b/db/migrate/20250920002438_create_eventos.rb
@@ -1,13 +1,13 @@
 class CreateEventos < ActiveRecord::Migration[8.0]
   def change
     create_table :eventos do |t|
-      t.string :titulo, null:false
-      t.text :conteudo, null:false
-      t.text :tags, array:true, default:[]
+      t.string :titulo, null: false
+      t.text :conteudo, null: false
+      t.text :tags, array: true, default: []
       t.string :url_imagem
-      t.string :local, null:false
-      t.column :data, :timestamptz, null:false
-      
+      t.string :local, null: false
+      t.column :data, :timestamptz, null: false
+
       t.references :autor, null: true, foreign_key: { on_delete: :nullify }
     end
   end

--- a/db/migrate/20250920002438_create_eventos.rb
+++ b/db/migrate/20250920002438_create_eventos.rb
@@ -6,7 +6,7 @@ class CreateEventos < ActiveRecord::Migration[8.0]
       t.text :tags, array:true, default:[]
       t.string :url_imagem
       t.string :local, null:false
-      t.datetime :data, null:false
+      t.column :data, :timestamptz, null:false
       
       t.references :autor, null: true, foreign_key: { on_delete: :nullify }
     end

--- a/db/migrate/20250920002438_create_eventos.rb
+++ b/db/migrate/20250920002438_create_eventos.rb
@@ -1,0 +1,14 @@
+class CreateEventos < ActiveRecord::Migration[8.0]
+  def change
+    create_table :eventos do |t|
+      t.string :titulo, null:false
+      t.text :conteudo, null:false
+      t.text :tags, array:true, default:[]
+      t.string :url_imagem
+      t.string :local, null:false
+      t.datetime :data, null:false
+      
+      t.references :autor, null: true, foreign_key: { on_delete: :nullify }
+    end
+  end
+end

--- a/test/controllers/artigos_controller_test.rb
+++ b/test/controllers/artigos_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class ArtigosControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @artigo = artigos(:one)
+  end
+
+  test "should get index" do
+    get artigos_url, as: :json
+    assert_response :success
+  end
+
+  test "should create artigo" do
+    assert_difference("Artigo.count") do
+      post artigos_url, params: { artigo: { autor_id: @artigo.autor_id, conteudo: @artigo.conteudo, data: @artigo.data, local: @artigo.local, tags: @artigo.tags, titulo: @artigo.titulo, url_imagem: @artigo.url_imagem } }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should show artigo" do
+    get artigo_url(@artigo), as: :json
+    assert_response :success
+  end
+
+  test "should update artigo" do
+    patch artigo_url(@artigo), params: { artigo: { autor_id: @artigo.autor_id, conteudo: @artigo.conteudo, data: @artigo.data, local: @artigo.local, tags: @artigo.tags, titulo: @artigo.titulo, url_imagem: @artigo.url_imagem } }, as: :json
+    assert_response :success
+  end
+
+  test "should destroy artigo" do
+    assert_difference("Artigo.count", -1) do
+      delete artigo_url(@artigo), as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/test/controllers/autors_controller_test.rb
+++ b/test/controllers/autors_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class AutorsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @autor = autors(:one)
+  end
+
+  test "should get index" do
+    get autors_url, as: :json
+    assert_response :success
+  end
+
+  test "should create autor" do
+    assert_difference("Autor.count") do
+      post autors_url, params: { autor: { email: @autor.email, foto: @autor.foto, nome: @autor.nome, senha: @autor.senha } }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should show autor" do
+    get autor_url(@autor), as: :json
+    assert_response :success
+  end
+
+  test "should update autor" do
+    patch autor_url(@autor), params: { autor: { email: @autor.email, foto: @autor.foto, nome: @autor.nome, senha: @autor.senha } }, as: :json
+    assert_response :success
+  end
+
+  test "should destroy autor" do
+    assert_difference("Autor.count", -1) do
+      delete autor_url(@autor), as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/test/controllers/autors_controller_test.rb
+++ b/test/controllers/autors_controller_test.rb
@@ -12,11 +12,17 @@ class AutorsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create autor" do
     assert_difference("Autor.count") do
-      post autors_url, params: { autor: { email: @autor.email, foto: @autor.foto, nome: @autor.nome, senha: @autor.senha } }, as: :json
+      post autors_url, params: { autor: { 
+        email: "novo_email_#{SecureRandom.hex(4)}@exemplo.com", 
+        foto: @autor.foto, 
+        nome: @autor.nome, 
+        senha: @autor.senha 
+      } }, as: :json
     end
 
     assert_response :created
   end
+
 
   test "should show autor" do
     get autor_url(@autor), as: :json

--- a/test/controllers/eventos_controller_test.rb
+++ b/test/controllers/eventos_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class EventosControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @evento = eventos(:one)
+  end
+
+  test "should get index" do
+    get eventos_url, as: :json
+    assert_response :success
+  end
+
+  test "should create evento" do
+    assert_difference("Evento.count") do
+      post eventos_url, params: { evento: { autor_id: @evento.autor_id, conteudo: @evento.conteudo, data: @evento.data, local: @evento.local, tags: @evento.tags, titulo: @evento.titulo, url_imagem: @evento.url_imagem } }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should show evento" do
+    get evento_url(@evento), as: :json
+    assert_response :success
+  end
+
+  test "should update evento" do
+    patch evento_url(@evento), params: { evento: { autor_id: @evento.autor_id, conteudo: @evento.conteudo, data: @evento.data, local: @evento.local, tags: @evento.tags, titulo: @evento.titulo, url_imagem: @evento.url_imagem } }, as: :json
+    assert_response :success
+  end
+
+  test "should destroy evento" do
+    assert_difference("Evento.count", -1) do
+      delete evento_url(@evento), as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/test/fixtures/artigos.yml
+++ b/test/fixtures/artigos.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  titulo: MyString
+  conteudo: MyText
+  tags: MyText
+  url_imagem: MyString
+  local: MyString
+  data: 2025-09-20 00:18:55
+  autor: one
+
+two:
+  titulo: MyString
+  conteudo: MyText
+  tags: MyText
+  url_imagem: MyString
+  local: MyString
+  data: 2025-09-20 00:18:55
+  autor: two

--- a/test/fixtures/artigos.yml
+++ b/test/fixtures/artigos.yml
@@ -3,7 +3,7 @@
 one:
   titulo: MyString
   conteudo: MyText
-  tags: MyText
+  tags: [MyText]
   url_imagem: MyString
   local: MyString
   data: 2025-09-20 00:18:55
@@ -12,7 +12,7 @@ one:
 two:
   titulo: MyString
   conteudo: MyText
-  tags: MyText
+  tags: [MyText]
   url_imagem: MyString
   local: MyString
   data: 2025-09-20 00:18:55

--- a/test/fixtures/autors.yml
+++ b/test/fixtures/autors.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  nome: MyString
+  foto: MyString
+  email: MyString
+  senha: MyString
+
+two:
+  nome: MyString
+  foto: MyString
+  email: MyString
+  senha: MyString

--- a/test/fixtures/autors.yml
+++ b/test/fixtures/autors.yml
@@ -3,11 +3,12 @@
 one:
   nome: MyString
   foto: MyString
-  email: MyString1
+  email: mystring1@example.com
   senha: MyString
 
 two:
   nome: MyString
   foto: MyString
-  email: MyString2
+  email: mystring2@example.com
   senha: MyString
+

--- a/test/fixtures/autors.yml
+++ b/test/fixtures/autors.yml
@@ -3,11 +3,11 @@
 one:
   nome: MyString
   foto: MyString
-  email: MyString
+  email: MyString1
   senha: MyString
 
 two:
   nome: MyString
   foto: MyString
-  email: MyString
+  email: MyString2
   senha: MyString

--- a/test/fixtures/eventos.yml
+++ b/test/fixtures/eventos.yml
@@ -3,7 +3,7 @@
 one:
   titulo: MyString
   conteudo: MyText
-  tags: MyText
+  tags: [MyText]
   url_imagem: MyString
   local: MyString
   data: 2025-09-20 00:24:38
@@ -12,7 +12,7 @@ one:
 two:
   titulo: MyString
   conteudo: MyText
-  tags: MyText
+  tags: [MyText]
   url_imagem: MyString
   local: MyString
   data: 2025-09-20 00:24:38

--- a/test/fixtures/eventos.yml
+++ b/test/fixtures/eventos.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  titulo: MyString
+  conteudo: MyText
+  tags: MyText
+  url_imagem: MyString
+  local: MyString
+  data: 2025-09-20 00:24:38
+  autor: one
+
+two:
+  titulo: MyString
+  conteudo: MyText
+  tags: MyText
+  url_imagem: MyString
+  local: MyString
+  data: 2025-09-20 00:24:38
+  autor: two

--- a/test/fixtures/eventos.yml
+++ b/test/fixtures/eventos.yml
@@ -1,19 +1,14 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  titulo: MyString
-  conteudo: MyText
-  tags: [MyText]
-  url_imagem: MyString
-  local: MyString
-  data: 2025-09-20 00:24:38
-  autor: one
+  nome: MyString
+  foto: MyString
+  email: mystring1@example.com
+  senha: MyString
 
 two:
-  titulo: MyString
-  conteudo: MyText
-  tags: [MyText]
-  url_imagem: MyString
-  local: MyString
-  data: 2025-09-20 00:24:38
-  autor: two
+  nome: MyString
+  foto: MyString
+  email: mystring2@example.com
+  senha: MyString
+

--- a/test/fixtures/eventos.yml
+++ b/test/fixtures/eventos.yml
@@ -1,14 +1,19 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  nome: MyString
-  foto: MyString
-  email: mystring1@example.com
-  senha: MyString
+  titulo: MyString
+  conteudo: MyText
+  tags: [MyText]
+  url_imagem: MyString
+  local: MyString
+  data: 2025-09-20 00:24:38
+  autor: one
 
 two:
-  nome: MyString
-  foto: MyString
-  email: mystring2@example.com
-  senha: MyString
-
+  titulo: MyString
+  conteudo: MyText
+  tags: [MyText]
+  url_imagem: MyString
+  local: MyString
+  data: 2025-09-20 00:24:38
+  autor: two

--- a/test/models/artigo_test.rb
+++ b/test/models/artigo_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArtigoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/autor_test.rb
+++ b/test/models/autor_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AutorTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/evento_test.rb
+++ b/test/models/evento_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## O que foi feito
- Adicionadas migrations para as tabelas: Autors, Artigos e Eventos
- Criados os models correspondentes com relacionamentos:
  - Autor: has_many :artigos, dependent: :nullify
  - Autor: has_many :eventos, dependent: :nullify
  - Artigo: belongs_to :autor, optional: true
  - Evento: belongs_to :autor, optional: true
- Scaffold gerado para Artigos, Eventos e Autors, incluindo controllers e views iniciais
- Ajustes nos nomes das colunas e tipos de dados para seguir boas práticas Rails

## Observações
- As validações de presença e relacionamentos estão configuradas nos models
- No banco, `autor_id` nas tabelas Artigos e Eventos é opcional, garantindo `nullify` ao deletar um autor
