### PR TITLE
:bug: fix: Adicionando campo satus em artigos e eventos

### DIFF
--- a/app/controllers/artigos_controller.rb
+++ b/app/controllers/artigos_controller.rb
@@ -46,6 +46,6 @@ class ArtigosController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def artigo_params
-      params.expect(artigo: [ :titulo, :conteudo, :tags, :url_imagem, :local, :data, :autor_id ])
+      params.expect(artigo: [ :titulo, :conteudo, :tags, :url_imagem, :local, :data, :autor_id, :status ])
     end
 end

--- a/app/controllers/eventos_controller.rb
+++ b/app/controllers/eventos_controller.rb
@@ -18,7 +18,7 @@ class EventosController < ApplicationController
     @evento = Evento.new(evento_params)
 
     if @evento.save
-      render json: @evento, status: :created, location: @evento
+      render { message: "evento criado", json: @evento }, status: :created, location: @evento
     else
       render json: @evento.errors, status: :unprocessable_entity
     end
@@ -46,6 +46,6 @@ class EventosController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def evento_params
-      params.expect(evento: [ :titulo, :conteudo, :tags, :url_imagem, :local, :data, :autor_id ])
+      params.expect(evento: [ :titulo, :conteudo, :tags, :url_imagem, :local, :data, :autor_id, :status ])
     end
 end

--- a/db/migrate/20250920212702_add_status_to_artigos_and_eventos.rb
+++ b/db/migrate/20250920212702_add_status_to_artigos_and_eventos.rb
@@ -1,0 +1,6 @@
+class AddStatusToArtigosAndEventos < ActiveRecord::Migration[8.0]
+  def change
+    add_column :artigos, :status, :string, default: "rascunho", null: false
+    add_column :eventos, :status, :string, default: "rascunho", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,65 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_09_20_212702) do
+  create_schema "auth"
+  create_schema "extensions"
+  create_schema "graphql"
+  create_schema "graphql_public"
+  create_schema "pgbouncer"
+  create_schema "realtime"
+  create_schema "storage"
+  create_schema "vault"
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "extensions.pg_stat_statements"
+  enable_extension "extensions.pgcrypto"
+  enable_extension "extensions.uuid-ossp"
+  enable_extension "graphql.pg_graphql"
+  enable_extension "pg_catalog.plpgsql"
+  enable_extension "vault.supabase_vault"
+
+  create_table "artigos", force: :cascade do |t|
+    t.string "titulo", null: false
+    t.text "conteudo", null: false
+    t.text "tags", default: [], array: true
+    t.string "url_imagem"
+    t.string "local", null: false
+    t.timestamptz "data", default: -> { "timezone('America/Sao_Paulo'::text, now())" }
+    t.bigint "autor_id"
+    t.string "status", default: "rascunho", null: false
+    t.index ["autor_id"], name: "index_artigos_on_autor_id"
+  end
+
+  create_table "autors", force: :cascade do |t|
+    t.string "nome", null: false
+    t.string "foto"
+    t.string "email", null: false
+    t.string "senha", null: false
+    t.index ["email"], name: "index_autors_on_email", unique: true
+  end
+
+  create_table "eventos", force: :cascade do |t|
+    t.string "titulo", null: false
+    t.text "conteudo", null: false
+    t.text "tags", default: [], array: true
+    t.string "url_imagem"
+    t.string "local", null: false
+    t.timestamptz "data", null: false
+    t.bigint "autor_id"
+    t.string "status", default: "rascunho", null: false
+    t.index ["autor_id"], name: "index_eventos_on_autor_id"
+  end
+
+  add_foreign_key "artigos", "autors", on_delete: :nullify
+  add_foreign_key "eventos", "autors", on_delete: :nullify
+end


### PR DESCRIPTION
### Descrição

* Adicionada a coluna `status` nas tabelas `artigos` e `eventos` via nova migration.
* Atualizados os strong parameters em `ArtigosController` e `EventosController` para permitir o campo `status`.
* Alterada a resposta do endpoint `POST /eventos` para retornar mensagem `"evento criado"` junto com os dados do evento.